### PR TITLE
do not report yet violations if guithread is not set yet

### DIFF
--- a/profiler/gui-thread-check.c
+++ b/profiler/gui-thread-check.c
@@ -63,6 +63,9 @@ simple_method_enter (MonoProfiler *prof, MonoMethod *method)
 			guithread = current_thread_id;
 			printf ("*** GUI THREAD INITIALIZED: %u\n", guithread); 
 		}
+		if (!guithread_set) {
+			return;
+		}
 		if (current_thread_id != guithread &&
 			!(strcmp (klass_name, "Object")==0 && strcmp (method_name, "Dispose")==0) &&
 			!(strcmp (klass_name, "Application")==0 && strcmp (method_name, "Invoke")==0) &&


### PR DESCRIPTION
Without this change, the call to Gtk.Application.Init() would
be reported as a violation itself.

(Detected, and bugfix tested, in MonoDevelop & Banshee)
