### PR TITLE
gui-thread-check.c: kill warnings

### DIFF
--- a/profiler/gui-thread-check.c
+++ b/profiler/gui-thread-check.c
@@ -24,6 +24,7 @@
  */
 
 #include <glib.h>
+#include <string.h>
 #include <mono/metadata/profiler.h>
 
 


### PR DESCRIPTION
Including &lt;string.h&gt; to kill these warnings:

gui-thread-check.c: In function 'simple_method_enter':
gui-thread-check.c:57:2: warning: implicit declaration of function 'strstr' [-Wimplicit-function-declaration]
gui-thread-check.c:57:6: warning: incompatible implicit declaration of built-in function 'strstr' [enabled by default]
gui-thread-check.c:61:3: warning: implicit declaration of function 'strcmp' [-Wimplicit-function-declaration]
