### PR TITLE
gui-thread-check.c: use fflush() after printf()

### DIFF
--- a/profiler/gui-thread-check.c
+++ b/profiler/gui-thread-check.c
@@ -25,6 +25,7 @@
 
 #include <glib.h>
 #include <mono/metadata/profiler.h>
+#include <stdio.h>
 
 
 extern pthread_t pthread_self ();
@@ -62,6 +63,7 @@ simple_method_enter (MonoProfiler *prof, MonoMethod *method)
 			guithread_set = TRUE;
 			guithread = current_thread_id;
 			printf ("*** GUI THREAD INITIALIZED: %u\n", guithread); 
+			fflush (NULL);
 			return;
 		}
 		if (!guithread_set) {
@@ -76,6 +78,7 @@ simple_method_enter (MonoProfiler *prof, MonoMethod *method)
 		) {
 			printf ("*** GTK CALL NOT IN GUI THREAD: %s.%s\n", klass_name, method_name);
 	        mono_stack_walk_no_il (stack_walk_fn, NULL);
+			fflush (NULL);
 		}
 	}
 }


### PR DESCRIPTION
Using fflush() right away after printf() calls avoids the buffers to
be written in an apparently complete-out-of-sync way from the point
of view of the developer. This problem would specially occur when
redirecting all output to a file this way:

  mono Foo.exe > out.txt 2>&1

Without this fix, all the output from gui-thread-check would appear
at the end of the file, instead of in between the output generated by
the program.
