### PR TITLE
Support new profiler API

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -6,9 +6,9 @@ test -z "$srcdir" && srcdir=.
 
 ORIGDIR=`pwd`
 cd $srcdir
-PROJECT=gui-thread-check
+PROJECT=guithreadcheck
 TEST_TYPE=-f
-FILE=profiler/gui-thread-check.c
+FILE=profiler/guithreadcheck.c
 
 DIE=0
 

--- a/configure.in
+++ b/configure.in
@@ -1,5 +1,5 @@
-AC_INIT(profiler/gui-thread-check.c)
-AM_INIT_AUTOMAKE(gui-thread-check, 0.1)
+AC_INIT(profiler/guithreadcheck.c)
+AM_INIT_AUTOMAKE(guithreadcheck, 0.1)
 AC_PROG_CC
 AM_PROG_LIBTOOL
 
@@ -7,7 +7,7 @@ PKG_CHECK_MODULES(PROFILER, mono-2 glib-2.0)
 
 AC_PATH_PROG(MCS, mcs)
 AC_PATH_PROG(MONO, mono)
-pkglibdir=$prefix/lib/gui-thread-check
+pkglibdir=$prefix/lib/guithreadcheck
 AC_SUBST(pkglibdir)
 
 AC_OUTPUT([

--- a/profiler/Makefile.am
+++ b/profiler/Makefile.am
@@ -1,9 +1,9 @@
 
-lib_LTLIBRARIES = libmono-profiler-gui-thread-check.la
+lib_LTLIBRARIES = libmono-profiler-guithreadcheck.la
 
-libmono_profiler_gui_thread_check_la_SOURCES = gui-thread-check.c
+libmono_profiler_guithreadcheck_la_SOURCES = guithreadcheck.c
 
-libmono_profiler_gui_thread_check_la_LIBADD = @PROFILER_LIBS@
+libmono_profiler_guithreadcheck_la_LIBADD = @PROFILER_LIBS@
 
 INCLUDES = @PROFILER_CFLAGS@ -Wall
 

--- a/profiler/profiler.mdproj
+++ b/profiler/profiler.mdproj
@@ -13,7 +13,7 @@
     <OutputPath>.</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gui-thread-check.c" />
+    <Compile Include="guithreadcheck.c" />
   </ItemGroup>
   <ProjectExtensions>
     <MonoDevelop>


### PR DESCRIPTION
List of changes to meet the new API:
1) Removed dashes in the module name to be able to use
`mono_profiler_init_<module name>` as a function name
(instead of mono_profiler_startup) which is required in the new API.
2) Use of mono_profiler_create instead of mono_profiler_install.
3) Using the new API for filter and callback in method_enter
Also this commit changes the use of printf to g_printf because
printf was not working on my machine but g_printf was working.